### PR TITLE
📖 CONTENT: refer to poetry docs for installation

### DIFF
--- a/py-pkgs/02-setup.ipynb
+++ b/py-pkgs/02-setup.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "Now we'll install the two main pieces of software we'll be using to help us create Python packages in this book:\n",
     "\n",
-    "1. [`poetry`\\index{poetry}](https://python-poetry.org/): software that will help us build our own Python packages. Poetry is under active development, thus we recommend referring to the official [Poetry documentation](https://python-poetry.org/docs/) for detailed installation instructions and support.\n",
+    "1. [`poetry`\\index{poetry}](https://python-poetry.org/): software that will help us build our own Python packages. `poetry` is under active development, thus we recommend referring to the official [`poetry` documentation](https://python-poetry.org/docs/) for detailed installation instructions and support.\n",
     "\n",
     "2. [`cookiecutter`\\index{cookiecutter}](https://github.com/cookiecutter/cookiecutter): software that will help us create packages from pre-made templates. It can be installed with `conda` as follows:\n",
     "\n",

--- a/py-pkgs/02-setup.ipynb
+++ b/py-pkgs/02-setup.ipynb
@@ -76,11 +76,7 @@
     "\n",
     "Now we'll install the two main pieces of software we'll be using to help us create Python packages in this book:\n",
     "\n",
-    "1. [`poetry`\\index{poetry}](https://python-poetry.org/): software that will help us build our own Python packages. You can install `poetry` for your specific operating system using the instructions in the official [documentation](https://python-poetry.org/docs/#installation). For example, on Mac OS or Linux the installation command is:\n",
-    "\n",
-    "    ```{prompt} bash \\$ auto\n",
-    "    $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -\n",
-    "    ```\n",
+    "1. [`poetry`\\index{poetry}](https://python-poetry.org/): software that will help us build our own Python packages. Poetry is under active development, thus we recommend referring to the official [Poetry documentation](https://python-poetry.org/docs/) for detailed installation instructions and support.\n",
     "\n",
     "2. [`cookiecutter`\\index{cookiecutter}](https://github.com/cookiecutter/cookiecutter): software that will help us create packages from pre-made templates. It can be installed with `conda` as follows:\n",
     "\n",
@@ -314,7 +310,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/py-pkgs/02-setup.ipynb
+++ b/py-pkgs/02-setup.ipynb
@@ -79,7 +79,7 @@
     "1. [`poetry`\\index{poetry}](https://python-poetry.org/): software that will help us build our own Python packages. You can install `poetry` for your specific operating system using the instructions in the official [documentation](https://python-poetry.org/docs/#installation). For example, on Mac OS or Linux the installation command is:\n",
     "\n",
     "    ```{prompt} bash \\$ auto\n",
-    "    $ curl -sSL https://install.python-poetry.org | python3 -\n",
+    "    $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -\n",
     "    ```\n",
     "\n",
     "2. [`cookiecutter`\\index{cookiecutter}](https://github.com/cookiecutter/cookiecutter): software that will help us create packages from pre-made templates. It can be installed with `conda` as follows:\n",


### PR DESCRIPTION
Looks like the command to install Poetry has been changed. The current command in the book is causing issues... This PR updates it. If this changes a lot, perhaps we just want to point at the installation page long-term so this is not so brittle?