### PR TITLE
✏️ TYPO: spelling error in Section 7.2

### DIFF
--- a/py-pkgs/07-releasing-versioning.ipynb
+++ b/py-pkgs/07-releasing-versioning.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While we'll discuss the full workflow for releasing a new version of your package in **{numref}`07:Checklist-for-releasing-a-new-package-version`**, we first want to dicuss version bumping. That is, how to increment the version of your package when you're preparing a new release. This can be done manually or automatically as we'll show below."
+    "While we'll discuss the full workflow for releasing a new version of your package in **{numref}`07:Checklist-for-releasing-a-new-package-version`**, we first want to discuss version bumping. That is, how to increment the version of your package when you're preparing a new release. This can be done manually or automatically as we'll show below."
    ]
   },
   {


### PR DESCRIPTION
"discuss" was misspelled at "dicuss" in the beginning paragraph of section 7.2.